### PR TITLE
Switch to weekly interval to schedule the meetings for the same day

### DIFF
--- a/other.yml
+++ b/other.yml
@@ -13,7 +13,7 @@ events:
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
-        months: 1
+        weeks: 4
       until: 2022-12-31  # required
   - summary: "Monthly SCS Onboarding Session"
     begin: 2022-07-01 15:05:00
@@ -26,5 +26,5 @@ events:
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
-        months: 1
+        weeks: 4
       until: 2022-12-31  # required


### PR DESCRIPTION
Using a monthly intervall schedules recurring events for different weekdays. Let's switch to a weekly interval to always have the Lean Coffee and Monthly Onboarding Session in the same day (Monday/Friday).

Fixes #7 