### PR TITLE
Proposal: SIG Monitoring at 11 instead of 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository contains various `yaml` files to announce public events, meetings and other interesting happenings of 
 our [Sovereign Cloud Stack](https://scs.community) community.
 
-## Import public SCS communuty calendar
+## Import public SCS community calendar
 The public calendar is automatically published at <https://sovereigncloudstack.github.io/calendar/scs.ics>. We recommend importing the calendar with an iCalendar client like [Thunderbird](https://support.mozilla.org/en-US/kb/creating-new-calendars#w_on-the-network-connect-to-your-online-calendars).
 
 ## Development

--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -155,7 +155,7 @@ events:
         weeks: 2
       until: 2022-12-31
   - summary: "SIG Monitoring"
-    begin: 2022-06-24 12:05:00
+    begin: 2022-06-24 11:05:00
     duration:
       minutes: 50
     description: |


### PR DESCRIPTION
The current time (12:05) for SIG Monitoing is not optimal:

- Putting the Meeting back-to-back with the hacking session creates one big block with no interlude to regenerate focus. This is problematic, especially in connection with the following:
- 12:00 is regular lunch time for many people working at the office or coworking spaces. So by missing lunch by an hour the focus of participants suffers.

Personal touch:
- The lack of "social regeneration time" poses a problem for me personally as a neurodivergent person. I think meeting at 11:05 and then having some time for myself would benefit my ability to participate in the hacking session starting at 13:00 in a focused way.

I am sure other people have additional reasons, be they based in time constraints and/or other personal preferences and necessities.

Thus, I would like to propose changing the time from 12:05 to 11:00 or 11:05.