### PR TITLE
Reschedule SIG community according to poll

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -132,7 +132,7 @@ events:
         weeks: 1
       until: 2022-12-31
   - summary: "SIG Community"
-    begin: 2022-06-29 11:05:00
+    begin: 2022-09-26 11:05:00
     duration:
       minutes: 50
     description: |


### PR DESCRIPTION
Let's reschedule our SIG community to Monday, 11:05 (starting from 2022-09-26) according to the votes recorded in the corresponding poll.

This conflicts with the Gaia-X Hackathon 5 on the first day, but the following Monday is a public holiday in Germany, so let's stick to 2022-09-26.

Does this work for all of you? @horazont, @tibeer, @ra-beer, @garloff?