### PR TITLE
Pinpoint version of yaml2ics and ics

### DIFF
--- a/.github/workflows/yaml2ics.yml
+++ b/.github/workflows/yaml2ics.yml
@@ -1,5 +1,5 @@
 name: Run yaml2ics
-    
+
 on:
   push:
     branches:
@@ -23,8 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install yaml2ics
-        pip install -r requirements.txt
+        pip install ics==0.8.0.dev0
+        pip install yaml2ics==0.1
     - name: Execute yaml2ics
       run: |
         mkdir ./calendar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-https://github.com/ics-py/ics-py/archive/refs/heads/main.zip


### PR DESCRIPTION
The yaml2ics project released a new version yesterday. Moreover, a dev version of ics has been released and thus requirements can be dropped.