### PR TITLE
add first round of coordinators to meetings.

### DIFF
--- a/onetimes.yml
+++ b/onetimes.yml
@@ -175,4 +175,5 @@ events:
       minutes: 110
     description: |
       Hands-on session on the gory details of the SCS reference implementation. We will dive into OSISM and the testbed in a shared terminal session.
+    Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech-Deepdive"

--- a/other.yml
+++ b/other.yml
@@ -10,7 +10,7 @@ events:
       This format offers a place where SCS operators can meet and discuss operating SCS with the various topics around that.
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
-	  Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:

--- a/other.yml
+++ b/other.yml
@@ -10,6 +10,7 @@ events:
       This format offers a place where SCS operators can meet and discuss operating SCS with the various topics around that.
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+	  Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:

--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -11,6 +11,7 @@ events:
       
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: SCS Project Team <project[at]scs.sovereignit.de>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -31,6 +32,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-iaas
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -48,6 +50,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-iaas
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -68,6 +71,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-iaas
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -85,6 +89,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-iaas
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -105,6 +110,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-ops-iam
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -122,6 +128,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-ops-iam
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -142,6 +149,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-team-container
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -163,6 +171,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-product-board
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -180,6 +189,7 @@ events:
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-community
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Eduard Itrich <itrich[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -200,6 +210,7 @@ events:
       Etherpad: https://input.osb-alliance.de/p/2022-scs-sig-standardization
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Alexander Diab <diab[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -237,6 +248,7 @@ events:
       Matrix channel for SIG related discussion and coordination: https://matrix.to/#/!ToxwzOWTBqSjxRAwuj:matrix.org?via=matrix.org
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
@@ -267,6 +279,7 @@ events:
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-release
       Etherpad: https://input.osb-alliance.de/p/2022-scs-sig-release
+      Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:


### PR DESCRIPTION
The idea with this is, that we note a coordinator for the meeting to have within the calendar item a contact that can be reached. Furthermore this should reflect a certain ownership of the call, so that it is clear who will prep it.

Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>