### PR TITLE
Cancel today's SIG Standard/Cert deep dive meeting

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -242,6 +242,8 @@ events:
       interval:
         weeks: 2
       until: 2022-12-31
+      except_on:
+        - 2022-10-27 14:05:00
   - summary: "SIG Monitoring"
     begin: 2022-06-24 12:05:00
     duration:


### PR DESCRIPTION
As proposed by @garloff, let's skip the meeting today.