### PR TITLE
Cancel WG Open Operations on 2022-11-11

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -353,3 +353,5 @@ events:
       interval:
         weeks: 1
       until: 2022-12-01
+      except_on:
+        - 2022-11-11 11:05:00


### PR DESCRIPTION
Since most of the WG members are in Berlin for a on-site meeting, I propose to postpone the meeting tomorrow.