### PR TITLE
Split SIG Monitoring into fortnightly meetings starting January

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -327,6 +327,41 @@ events:
     repeat:
       interval:
         weeks: 1
+      until: 2023-01-01
+  - summary: "SIG Monitoring"
+    begin: 2023-01-06 12:05:00
+    duration:
+      minutes: 50
+    description: |
+      The Special Interest Group (SIG) Monitoring meets on a fortnightly base (alternating with the audit log WG) to discuss the monitoring needs of SCS Operators, Users and Integrators. Together we shape how monitoring and observability within the SCS landscape looks like.
+      
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-monitoring
+      Etherpad: https://input.osb-alliance.de/p/2023-scs-sig-monitoring
+      Matrix channel for SIG related discussion and coordination: https://matrix.to/#/!ToxwzOWTBqSjxRAwuj:matrix.org?via=matrix.org
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 2
+      until: 2023-06-30
+  - summary: "Audit Logging Breakout – SIG Monitoring"
+    begin: 2023-01-13 12:05:00
+    duration:
+      minutes: 50
+    description: |
+      The Special Interest Group (SIG) Monitoring has created an Audit Logging Working Group which meets on a fortnightly base to discuss the audit logging needs of SCS Operators, Users and Integrators. 
+      
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-monitoring-audit-log-wg
+      Etherpad: https://input.osb-alliance.de/p/2023-scs-sig-monitoring-audit-log-wg
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Jonas Schäfer <jonas.schaefer@cloudandheat.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 2
       until: 2023-06-30
   - summary: "SIG IAM"
     begin: 2022-07-08 10:05:00


### PR DESCRIPTION
This is the result of the Audit Log kickoff today. We figured that a fortnightly rhythm for the audit log discussions should be sufficient, as should be for the standard workload of the SIG Monitoring.

Hence we split the SIG Monitoring slot for convenience of slotfinding.

Signed-off-by: Jonas Schäfer <jonas.schaefer@cloudandheat.com>