### PR TITLE
Streamline url of etherpad for SIG community

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -236,7 +236,7 @@ events:
       For the time being, we will have the Community SIG Call on a bi-weekly basis.
 
       Kanban-Board: https://github.com/orgs/SovereignCloudStack/projects/6/views/14
-      Etherpad: https://input.osb-alliance.de/p/2022-sig-community
+      Etherpad: https://input.osb-alliance.de/p/2022-scs-sig-community
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-community
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611


### PR DESCRIPTION
All etherpad within our community start with `2022-scs`. Rename the URL of the SIG community accordingly.