### PR TITLE
cancel Lean SCS Operator Coffee in CW50

### DIFF
--- a/other.yml
+++ b/other.yml
@@ -16,6 +16,8 @@ events:
       interval:
         weeks: 4
       until: 2023-06-30  # required
+      except_on:
+        - 2022-12-12
   - summary: "Open Hacking Session"
     begin: 2022-07-01 13:05:00
     duration:


### PR DESCRIPTION
There is a SCS Projectteam internal workshop on Dec 12th/13th happening. Due to that there will not be a Lean Coffee.

Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>