### PR TITLE
Postpone GXFS lightning talk to January 12th

### DIFF
--- a/lightning_talks.yml
+++ b/lightning_talks.yml
@@ -3,7 +3,7 @@ timezone: Europe/Berlin
 
 events:
   - summary: "Insights into running Gaia-X Federation Services on Sovereign Cloud Stack."
-    begin: 2022-12-08 15:45:00         # uses default timezone above
+    begin: 2023-01-12 15:45:00         # uses default timezone above
     duration:
       minutes: 15
     description: |


### PR DESCRIPTION
Due to sickness we have to postpone the scheduled lightning talk on GXFS microservices to January 12th (the week before the deep dive session!)

Signed-off-by: Eduard Itrich <eduard@itrich.net>