### PR TITLE
re-schedule SIG Market to be weekly on thursdays from 11:05 to 11:35.

### DIFF
--- a/archive/2022/team_meetings.yml
+++ b/archive/2022/team_meetings.yml
@@ -166,3 +166,20 @@ events:
       until: 2022-11-21
       except_on:
         - 2022-10-03 11:05:00
+  - summary: "SIG SCS Market"
+    begin: 2022-12-05 11:05:00
+    duration:
+      minutes: 50
+    description: |
+      The mission of the special interest group „SCS Market“ is to discuss and agree upon measures and actions to increase the adoption and dissemination of SCS as a technology standard and a technology stack. We will collect ideas and decide, where SCS can sensibly be introduced, presented and deployed and what resources must be provided and applied, in order to successfully bring SCS in usage.
+
+      Etherpad: https://input.osb-alliance.de/p/2022-scs-sig-market
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-market
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Alexander Diab <diab[at]osb-alliance.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 4
+      until: 2022-12-31

--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -292,9 +292,9 @@ events:
         - 2022-12-23 10:05:00
         - 2022-12-30 10:05:00
   - summary: "SIG SCS Market"
-    begin: 2022-12-05 11:05:00
+    begin: 2023-01-12 11:05:00
     duration:
-      minutes: 50
+      minutes: 30
     description: |
       The mission of the special interest group „SCS Market“ is to discuss and agree upon measures and actions to increase the adoption and dissemination of SCS as a technology standard and a technology stack. We will collect ideas and decide, where SCS can sensibly be introduced, presented and deployed and what resources must be provided and applied, in order to successfully bring SCS in usage.
 
@@ -306,5 +306,5 @@ events:
     location: "https://conf.scs.koeln:8443/SCS-Tech"
     repeat:
       interval:
-        weeks: 4
+        weeks: 1
       until: 2023-06-30


### PR DESCRIPTION
Discussed and requested by @alexander-diab.
The 2022 entry is moved to the archive file.

Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>