### PR TITLE
switch to teams for audit logging breakout

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -271,7 +271,7 @@ events:
 
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-monitoring-audit-log-wg
       Etherpad: https://input.osb-alliance.de/p/2023-scs-sig-monitoring-audit-log-wg
-      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Teams Meeting Link: https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODI2N2Q1MWMtZWEzNS00NjFhLWFkODAtM2YwNTc2ZGE4NDYw%40thread.v2/0?context=%7b%22Tid%22%3a%22d04f4717-5a6e-4b98-b3f9-6918e0385f4c%22%2c%22Oid%22%3a%2219c0feb6-cd2d-4eaa-8f9f-7c1b6e19c54a%22%7d
       Dial-In: +49-221-292772-611
       Coordinator: Jonas Schäfer <jonas.schaefer@cloudandheat.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"


### PR DESCRIPTION
Some participants require this to be a teams session. We want to be inclusive, so for this meeting we will use teams.

Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>