### PR TITLE
Fix missing time in except_on for fullcalendar.io

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -263,7 +263,7 @@ events:
         weeks: 2
       until: 2023-06-30
       except_on:
-        - 2023-02-17
+        - 2023-02-17 12:05:00
   - summary: "SIG Monitoring"
     begin: 2023-02-17 12:05:00
     duration:


### PR DESCRIPTION
Signed-off-by: Eduard Itrich <eduard@itrich.net>