### PR TITLE
Shift and cancel SIG Standardization

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -243,7 +243,28 @@ events:
     repeat:
       interval:
         weeks: 2
-      until: 2023-12-20
+      until: 2023-02-22
+  - summary: "SIG Standardization/Certification"
+    begin: 2023-03-16 14:05:00
+    duration:
+      minutes: 50
+    description: |
+      Special Interest Group to discuss and align our activities and approach to standardization and certification.
+
+      The idea is to agree on relevant standards that are fulfilled by the SCS reference implementation (at IaaS layer - optional, at CaaS layer, federation and possibly even operational transparency). In general, standards should be defined such that they can be fulfilled by partners that do only use some of the modules of the reference implementation or even none of them.
+      Main goal for standards is to create a high level of assurance for interoperability – a service that is developed against SCS CaaS standards should work without any adaptation of the service and its deployment/operations automation of all clouds that have a SCS-certified CaaS implementation. For sovereignty and transparency aspects, we may provide assurance also with respect to open source and open operations, but these are topics for later. See https://scs.sovereignit.de/nextcloud/apps/files/?dir=/Sovereign%20Cloud%20Stack/Certification&fileid=61594
+      This group should discuss strategy and most importantly align on which standards we need and then work with the teams to align on existing or to be created standards. We should take the user perspective: As a member of a DevOps team developing a service (think SaaS or PaaS) for SCS, I need XXXX.
+
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-standardization
+      Etherpad: https://input.osb-alliance.de/p/2023-scs-sig-standardization
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Alexander Diab <diab[at]osb-alliance.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 2
+      until: 2023-06-30
   - summary: "SIG Monitoring"
     begin: 2023-01-06 12:05:00
     duration:


### PR DESCRIPTION
Cancel today's SIG Standardization (due to ALASCA Tech Talk) and shift recurrence by one week, starting from 2023-03-16 as suggested by @fkr.