### PR TITLE
Move SIG std/cert from 2023-04-13 to -04-20.

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -391,6 +391,10 @@ events:
       interval:
         weeks: 2
       until: 2023-06-30
+      except_on:
+        - 2023-04-13 14:05:00
+      also_on:
+        - 2023-04-20 14:05:00
   - summary: "SIG Monitoring"
     begin: 2023-01-06 12:05:00
     duration:


### PR DESCRIPTION
Alex is traveling, Kurt in the IAM workshop, so we lack leadership for 2023-04-13. Let's not just cancel, but rather move by a week.