### PR TITLE
Don't pin yaml2ics on (old) 0.1 version

### DIFF
--- a/.github/workflows/yaml2ics.yml
+++ b/.github/workflows/yaml2ics.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install ics==0.8.0.dev0
-        pip install yaml2ics
+        pip install yaml2ics==main
         pip install pyyaml
     - name: Run communitycall.py
       run: |

--- a/.github/workflows/yaml2ics.yml
+++ b/.github/workflows/yaml2ics.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install ics==0.8.0.dev0
-        pip install yaml2ics==0.1
+        pip install yaml2ics
         pip install pyyaml
     - name: Run communitycall.py
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-yaml2ics==0.1
+yaml2ics


### PR DESCRIPTION
0.1 does not yet understand the `also_on` tag, which we want to start using.