### PR TITLE
add SCS Summit to the calender

### DIFF
--- a/onetimes.yml
+++ b/onetimes.yml
@@ -98,3 +98,19 @@ events:
       Dial-In: +49-221-292772-611
       Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
+  - summary: "SCS Summit 2023"
+    begin: 2023-05-23 12:00:00
+    duration:
+      minutes: 360
+    description: |
+      The SCS Summit - Day 1.
+	  See https://scs.community/summit/ for all details!
+    location: "Berlin-Brandenburg Academy of Sciences and Humanities, Markgrafenstrasse 38, Berlin"
+  - summary: "SCS Summit 2023"
+    begin: 2023-05-24 09:00:00
+    duration:
+      minutes: 240
+    description: |
+      The SCS Summit - Day 2.
+	  See https://scs.community/summit/ for all details!
+    location: "Berlin-Brandenburg Academy of Sciences and Humanities, Markgrafenstrasse 38, Berlin"

--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -88,6 +88,7 @@ events:
       until: 2023-06-30
       except_on:
         - 2023-04-12 10:05:00
+        - 2023-05-24 10:05:00
   - summary: "Team OPS / IAM Sprint Review/Planning and Refinement"
     begin: 2022-06-23 10:05:00
     duration:
@@ -598,6 +599,8 @@ events:
       interval:
         weeks: 2
       until: 2023-03-08
+      except_on:
+        - 2023-05-24 11:35:00
   - summary: "Team IAM Sprint Review/Planning and Refinement"
     begin: 2023-03-22 11:35:00
     duration:


### PR DESCRIPTION
While here: Skip IaaS and IAM calls on the second summit day.