### PR TITLE
A few more cancelations due to the SCS summit:

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -356,6 +356,7 @@ events:
         - 2023-01-02 14:05:00
         - 2023-04-10 14:05:00
         - 2023-05-01 14:05:00
+        - 2023-05-22 14:05:00
   - summary: "SIG Community"
     begin: 2022-12-19 11:05:00
     duration:
@@ -540,6 +541,7 @@ events:
         - 2022-12-23 10:05:00
         - 2022-12-30 10:05:00
         - 2023-03-03 10:05:00
+        - 2023-05-19 10:05:00
   - summary: "SIG SCS Market"
     begin: 2023-01-12 11:05:00
     duration:
@@ -603,8 +605,6 @@ events:
       interval:
         weeks: 2
       until: 2023-03-08
-      except_on:
-        - 2023-05-24 11:35:00
   - summary: "Team IAM Sprint Review/Planning and Refinement"
     begin: 2023-03-22 11:35:00
     duration:
@@ -646,6 +646,7 @@ events:
       except_on:
         - 2023-04-12 11:35:00
         - 2023-05-10 11:35:00
+        - 2023-05-24 11:35:00
   - summary: "SIG Release"
     begin: 2023-02-22 14:05:00
     duration:


### PR DESCRIPTION
Product Board 2023-05-22
Team IAM 2023-05-24 (cancelation was ineffective before) SIG IAM 2023-05-19 (OK, not really due to summit)