### PR TITLE
Move Thu meets 1hr earlier.

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -198,7 +198,7 @@ events:
     repeat:
       interval:
         weeks: 2
-      until: 2023-12-22
+      until: 2023-07-22
       except_on:
         - 2023-05-18 10:05:00
         - 2023-07-13 10:05:00
@@ -219,9 +219,48 @@ events:
     repeat:
       interval:
         weeks: 2
-      until: 2023-12-22
+      until: 2023-07-22
       except_on:
         - 2023-04-13 10:05:00
+  - summary: "Team OPS Sprint Review/Planning and Refinement"
+    begin: 2023-07-27 09:05:00
+    duration:
+      minutes: 50
+    description: |
+      This is our bi-weekly sprint review, planning and refinement meeting for Team OPS.
+      - Sprint review: Let's look at the stories that were being worked on and completed.
+      - Backlog refinement: Let's look at the backlog and work on refining the stories such that they can be worked on.
+      - Sprint planning: Let's look at what we can achieve in the next cycle.
+
+      Kanban-Board: https://github.com/orgs/SovereignCloudStack/projects/6/views/8
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/ops
+      Etherpad: https://input.scs.community/2023-scs-team-ops
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 2
+      until: 2023-12-22
+  - summary: "Team OPS Meeting"
+    begin: 2023-08-03 09:05:00
+    duration:
+      minutes: 50
+    description: |
+      This is our bi-weekly meeting for Team OPS in which we deep-dive into topics.
+      There is a github issue to which items that need to be discussed can be added: https://github.com/SovereignCloudStack/issues/issues/51
+
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/ops
+      Etherpad: https://input.scs.community/2023-scs-team-ops
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Felix Kronlage-Dammers <fkr[at]osb-alliance.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 2
+      until: 2023-12-22
   - summary: "Team Container Sprint Review/Planning and Refinement"
     begin: 2022-06-27 10:05:00
     duration:
@@ -696,7 +735,7 @@ events:
       except_on:
         - 2023-03-01 14:05:00
   - summary: "Team IAM Sprint Review/Planning and Refinement"
-    begin: 2023-07-27 11:35:00
+    begin: 2023-07-27 10:35:00
     duration:
       minutes: 50
     description: |
@@ -717,7 +756,7 @@ events:
         weeks: 2
       until: 2023-12-22
   - summary: "Team IAM Meeting"
-    begin: 2023-08-03 11:35:00
+    begin: 2023-08-03 10:35:00
     duration:
       minutes: 50
     description: |


### PR DESCRIPTION
This moves Ops to 9:05 CEST and IAM to 10:35 CEST, avoiding weekly conflicts for Gonicus and others.
(Discussed in PB 2023-07-24.)