### PR TITLE
remove open hacking session as discussed in today's product board

### DIFF
--- a/other.yml
+++ b/other.yml
@@ -31,7 +31,7 @@ events:
     repeat:
       interval:
         weeks: 1
-      until: 2023-12-22  # required
+      until: 2023-08-18  # required
       except_on:
         - 2022-12-23 13:05:00
         - 2022-12-30 13:05:00


### PR DESCRIPTION
Since it rarely is filled with people, we dediced to remove it and instead schedule specific sessions when they happen. That way everone knows wether something will really happen.