### PR TITLE
Change Team IAM and ProductBoard to use 2024 hedgedocs.

### DIFF
--- a/team_meetings.yml
+++ b/team_meetings.yml
@@ -72,7 +72,7 @@ events:
       - What are key OSS/industry trends to take into account?
 
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/product-board
-      Etherpad: https://input.scs.community/2023-scs-product-board
+      Etherpad: https://input.scs.community/2024-scs-product-board
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
       Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>
@@ -169,7 +169,7 @@ events:
 
       Kanban-Board: https://github.com/orgs/SovereignCloudStack/projects/6/views/27
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/iam
-      Etherpad: https://input.scs.community/2023-scs-team-iam
+      Etherpad: https://input.scs.community/2024-scs-team-iam
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
       Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>
@@ -186,7 +186,7 @@ events:
       This is our bi-weekly meeting for Team IAM in which we deep-dive into topics.
 
       Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/iam
-      Etherpad: https://input.scs.community/2023-scs-team-iam
+      Etherpad: https://input.scs.community/2024-scs-team-iam
       Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
       Dial-In: +49-221-292772-611
       Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>


### PR DESCRIPTION
We had 2023 in the file names, so we need new hedgedoc filenames with
2024. Do this for my meetings.

Inside the hedge docs, I also added links to minimize confusion. For reference of old minutes, we of course continue to rely on https://github.com/SovereignCloudStack/minutes/