### PR TITLE
Add IaaS IPv4 Breakout session to the calendar

### DIFF
--- a/teams/iaas/onetimes.yml
+++ b/teams/iaas/onetimes.yml
@@ -40,3 +40,16 @@ events:
       Dial-In: +49-221-292772-611
       Coordinator: Kurt Garloff <garloff[at]osb-alliance.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
+  - summary: "IaaS Breakout room - IPv4/6 Network Standardization"
+    begin: 2024-04-11 14:05:00
+    duration:
+      minutes: 50
+    description: |
+      See this hedgedoc:
+      https://input.scs.community/2023-scs-team-iaas?view#2024-03-27:~:text=breakout%20session%20for%20discussion%20of%20the%20whole%20standard%20will%20be%20organized
+      Issue Link: https://github.com/SovereignCloudStack/issues/issues/167
+      PR Link: https://github.com/SovereignCloudStack/standards/pull/522
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Patrick Thiem <patrick.thiem[at]cloudandheat.com>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"


### PR DESCRIPTION
We need a breakout session regarding the IPv4/6 Networking standardization to discuss further details.