### PR TITLE
postpone IaaS Breakout Session for the DNS Standard

### DIFF
--- a/teams/iaas/onetimes.yml
+++ b/teams/iaas/onetimes.yml
@@ -54,7 +54,7 @@ events:
       Coordinator: Patrick Thiem <patrick.thiem[at]cloudandheat.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
   - summary: "IaaS Breakout room - DNS Standardization"
-    begin: 2024-06-17 14:05:00
+    begin: 2024-06-24 14:05:00
     duration:
       minutes: 50
     description: |

--- a/teams/iaas/onetimes.yml
+++ b/teams/iaas/onetimes.yml
@@ -54,7 +54,7 @@ events:
       Coordinator: Patrick Thiem <patrick.thiem[at]cloudandheat.com>
     location: "https://conf.scs.koeln:8443/SCS-Tech"
   - summary: "IaaS Breakout room - DNS Standardization"
-    begin: 2024-06-24 14:05:00
+    begin: 2024-06-24 15:05:00
     duration:
       minutes: 50
     description: |


### PR DESCRIPTION
Postpone this by 1 week due to conflict with today's product board meeting.