### PR TITLE
schedule SIG Std/Cert on 2024-08-15

### DIFF
--- a/teams/sig_standard_cert/onetimes.yml
+++ b/teams/sig_standard_cert/onetimes.yml
@@ -14,3 +14,16 @@ events:
       Dial-In: +49-221-292772-611
       Coordinator: ?
     location: "https://conf.scs.koeln:8443/SCS-Tech"
+  - summary: Extraordinary meeting of SIG Standardization/Certification
+    begin: 2024-08-15 14:05:00
+    duration:
+      minutes: 50
+    description: |
+      This week is not a regular SIG Std/Cert week, but Matthias thinks it would be good to
+      have an additional meeting.
+      
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-standardization
+      Etherpad: https://input.scs.community/2024-scs-sig-standardization
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Matthias Büchse <matthias.buechse[at]cloudandheat.com>


### PR DESCRIPTION
An additional meeting because tomorrow multiple people (myself included) can't attend, and we usually have enough to talk about. I try to avoid the designated overflow slot because it's usually too late in the day for me and my family.