### PR TITLE
fix: end of SIG Central API MVP

### DIFF
--- a/teams/sig_central_api/team_meetings.yml
+++ b/teams/sig_central_api/team_meetings.yml
@@ -18,7 +18,7 @@ events:
     repeat:
       interval:
         weeks: 2
-      until: 2024-08-27
+      until: 2024-08-28
   - summary: "SIG Central API"
     begin: 2024-09-10 10:05:00
     duration:


### PR DESCRIPTION
Hi @o-otte, sorry for another PR. Didn't know `until` means `until except`, which resulted in the appointment from today is missing in the calendar now. I just add one more day, which should fix it.