### PR TITLE
Remove Team IAM/Sec in cwk 44 (ALASCA summit).

### DIFF
--- a/teams/iam_n_sec/team_meetings.yml
+++ b/teams/iam_n_sec/team_meetings.yml
@@ -4,6 +4,7 @@ timezone: Europe/Berlin
 events:
   - summary: "Team IAM and Security Sprint Review/Planning and Refinement"
     begin: 2024-01-10 11:35:00
+    # EVEN WEEKS
     duration:
       minutes: 50
     description: |
@@ -30,8 +31,10 @@ events:
         - 2024-07-10 11:35:00
         - 2024-09-04 11:35:00
         - 2024-10-16 11:35:00
+        - 2024-10-30 11:35:00
   - summary: "Team IAM and Security Meeting"
     begin: 2024-01-17 11:35:00
+    # UNEVEN WEEKS
     duration:
       minutes: 50
     description: |


### PR DESCRIPTION
Please add additional cancelations (e.g. b/c of ALASCA, Reformationstag, Allerheiligen, ...)