### PR TITLE
cancel SIG Std/Cert meeting on 2025-08-14

### DIFF
--- a/teams/sig_standard_cert/team_meetings.yml
+++ b/teams/sig_standard_cert/team_meetings.yml
@@ -87,3 +87,4 @@ events:
         - 2025-05-29 14:05:00  # Ascension day
         - 2025-06-05 14:05:00  # because of FOCIS hackathon
         - 2025-06-19 14:05:00  # public holiday in southern Germany, and others are gone as well
+        - 2025-08-14 14:05:00  # holiday season; most people are on vacation


### PR DESCRIPTION
As [decided on last meeting](https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20250807.md#next-weeks-meeting)