### PR TITLE
skip due to the SCS Summit on that day

### DIFF
--- a/teams/sig_standard_cert/team_meetings.yml
+++ b/teams/sig_standard_cert/team_meetings.yml
@@ -87,3 +87,4 @@ events:
       until: 2026-12-18
       except_on:
         - 2026-02-26 14:05:00  # Yaook-SCS-operator Hackathon
+        - 2026-05-21 14:05:00  # SCS Summit 2026


### PR DESCRIPTION
Likely most if not all participants will be at the SCS Summit.