### PR TITLE
Move SIG Std/Cert series back by a week

### DIFF
--- a/teams/sig_standard_cert/team_meetings.yml
+++ b/teams/sig_standard_cert/team_meetings.yml
@@ -88,7 +88,7 @@ events:
       except_on:
         - 2026-02-26 14:05:00  # Yaook-SCS-operator Hackathon
         - 2026-05-21 14:05:00  # SCS Summit 2026
-  - summary: "SIG Standardization/Certification"
+  - summary: "SIG Standardization/Certification" # Move back by a week due to ALASCA Hackathon and Summit
     begin: 2026-07-09 14:05:00
     uid: sig-std-crt-2026-b@docs.scs.community
     duration:

--- a/teams/sig_standard_cert/team_meetings.yml
+++ b/teams/sig_standard_cert/team_meetings.yml
@@ -84,7 +84,29 @@ events:
     repeat:
       interval:
         weeks: 2
-      until: 2026-12-18
+      until: 2026-06-26
       except_on:
         - 2026-02-26 14:05:00  # Yaook-SCS-operator Hackathon
         - 2026-05-21 14:05:00  # SCS Summit 2026
+  - summary: "SIG Standardization/Certification"
+    begin: 2026-07-09 14:05:00
+    uid: sig-std-crt-2026-b@docs.scs.community
+    duration:
+      minutes: 50
+    description: |
+      In this Special Interest Group, we discuss and align our activities and approach to standardization and certification. That is to say, we devise and refine the relevant concepts and processes; we work on a roadmap for new certificate versions; and we align on which standards are desireable for each certificate subject. We then work with the teams to align on existing or new standards.
+
+      Besides aspects of openness and sovereignty, the main goal of our standards is interoperability. We should take the user perspective: As a member of a DevOps team developing a service (think SaaS or PaaS) for SCS, I need XYZ. Every standard should be abstract enough to work regardless of the SCS reference implementation.
+
+      This SIG is a joint effort by SCS and ALASCA.
+
+      Minutes: https://github.com/SovereignCloudStack/minutes/tree/main/sig-standardization
+      HedgeDoc: https://input.scs.community/2026-scs-sig-standardization
+      Jitsi server on https://conf.scs.koeln:8443/SCS-Tech
+      Dial-In: +49-221-292772-611
+      Coordinator: Matthias Büchse <matthias.buechse[at]alasca.cloud>
+    location: "https://conf.scs.koeln:8443/SCS-Tech"
+    repeat:
+      interval:
+        weeks: 2
+      until: 2026-12-18


### PR DESCRIPTION
Multiple collisions with current schedule

- ALASCA hackathon, 2026-07-02
- ALASCA summit adjacent, 2026-11-05
- other absences

Therefore move series by a week.