### PR TITLE
Cancel SCS Community Meeting 2026-08-07.

### DIFF
--- a/other.yml
+++ b/other.yml
@@ -44,6 +44,7 @@ events:
       until: 2026-12-18 # required
       except_on:
         - 2026-05-15 11:05:00  # Skip due to bridge day
+        - 2026-08-07 11:05:00  # Vacation time
   - summary: "Lean SCS Operator Coffee"
     begin: 2026-01-08 10:05:00
     uid: scs-lean-coffee-2026@docs.scs.community


### PR DESCRIPTION
Too many people on vacation, not just from project board.